### PR TITLE
Upgrade to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ outputs:
   version:
     description: 'Version of the hlint tool (same as input, if provided)'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'arrow-down-circle'


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/